### PR TITLE
update

### DIFF
--- a/Sonic Battle Prototype/Scenes/Hubs/city_hub.tscn
+++ b/Sonic Battle Prototype/Scenes/Hubs/city_hub.tscn
@@ -28,6 +28,11 @@ surface_material_override/0 = ExtResource("2_m2au7")
 [node name="InvisibleWalls" parent="." instance=ExtResource("2_1lcbb")]
 transform = Transform3D(2.335, 0, 0, 0, 2.13, 0, 0, 0, 2.13, 1.06559, 0, 0)
 
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
+stream = ExtResource("8_kdbtx")
+volume_db = -7.0
+autoplay = true
+
 [node name="Ring" parent="." instance=ExtResource("7_kmrjo")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.28553, 6.54966e-07, 2.16711)
 
@@ -53,11 +58,6 @@ transform = Transform3D(0.05, 0, 0, 0, 0.05, 0, 0, 0, 0.05, 4.8353, -3.27483e-07
 
 [node name="lamp5" parent="lamps" instance=ExtResource("6_p3ikg")]
 transform = Transform3D(0.05, 0, 0, 0, 0.05, 0, 0, 0, 0.05, -1.28896, -3.27483e-07, 2.91571)
-
-[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
-stream = ExtResource("8_kdbtx")
-volume_db = -7.0
-autoplay = true
 
 [node name="Markers" type="Marker3D" parent="."]
 

--- a/Sonic Battle Prototype/Scenes/stages/amys_room.tscn
+++ b/Sonic Battle Prototype/Scenes/stages/amys_room.tscn
@@ -12,12 +12,12 @@ texture_filter = 2
 [node name="Amys_Room" type="Node3D"]
 
 [node name="amy_s_room" parent="." instance=ExtResource("1_w46to")]
-transform = Transform3D(0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0)
+transform = Transform3D(0.15, 0, 0, 0, 0.2, 0, 0, 0, 0.15, 0, 0, 0)
 
 [node name="amy_s_room" parent="amy_s_room" index="0"]
 surface_material_override/0 = SubResource("StandardMaterial3D_oh7il")
 
 [node name="InvisibleWalls" parent="." instance=ExtResource("2_nh2sa")]
-transform = Transform3D(1.005, 0, 0, 0, 1, 0, 0, 0, 0.495, 0, -0.762953, 0)
+transform = Transform3D(0.755, 0, 0, 0, 0.751, 0, 0, 0, 0.372, 0, -0.762953, 0)
 
 [editable path="amy_s_room"]

--- a/Sonic Battle Prototype/Scenes/stages/chao_ruin.tscn
+++ b/Sonic Battle Prototype/Scenes/stages/chao_ruin.tscn
@@ -12,12 +12,12 @@ texture_filter = 2
 [node name="Chao_Ruin" type="Node3D"]
 
 [node name="chao_ruin" parent="." instance=ExtResource("1_lja5g")]
-transform = Transform3D(0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0)
+transform = Transform3D(0.15, 0, 0, 0, 0.2, 0, 0, 0, 0.15, 0, 0, 0)
 
 [node name="chao_ruin" parent="chao_ruin" index="0"]
 surface_material_override/0 = SubResource("StandardMaterial3D_7cxbx")
 
 [node name="InvisibleWalls" parent="." instance=ExtResource("2_fcckd")]
-transform = Transform3D(0.7, 0, 0, 0, 1, 0, 0, 0, 0.695, 0, -0.857985, 0)
+transform = Transform3D(0.525, 0, 0, 0, 0.75, 0, 0, 0, 0.521, 0, -0.857985, 0)
 
 [editable path="chao_ruin"]

--- a/Sonic Battle Prototype/Scenes/stages/colosseum.tscn
+++ b/Sonic Battle Prototype/Scenes/stages/colosseum.tscn
@@ -12,12 +12,12 @@ texture_filter = 2
 [node name="Colosseum" type="Node3D"]
 
 [node name="colosseum" parent="." instance=ExtResource("1_sk5p8")]
-transform = Transform3D(0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0)
+transform = Transform3D(0.5, 0, 0, 0, 0.2, 0, 0, 0, 0.5, 0, 0, 0)
 
 [node name="colosseum" parent="colosseum" index="0"]
 surface_material_override/0 = SubResource("StandardMaterial3D_vl8se")
 
 [node name="InvisibleWalls" parent="." instance=ExtResource("2_rgyl8")]
-transform = Transform3D(0.335, 0, 0, 0, 0.335, 0, 0, 0, 0.335, 0, -0.43347, 0)
+transform = Transform3D(0.85, 0, 0, 0, 0.85, 0, 0, 0, 0.85, 0, -0.43347, 0)
 
 [editable path="colosseum"]

--- a/Sonic Battle Prototype/Scenes/stages/emerald_beach.tscn
+++ b/Sonic Battle Prototype/Scenes/stages/emerald_beach.tscn
@@ -12,12 +12,12 @@ texture_filter = 2
 [node name="Emerald_Beach" type="Node3D"]
 
 [node name="emerald_beach" parent="." instance=ExtResource("1_mjnpd")]
-transform = Transform3D(0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0)
+transform = Transform3D(0.15, 0, 0, 0, 0.2, 0, 0, 0, 0.15, 0, 0, 0)
 
 [node name="emerald_beach" parent="emerald_beach" index="0"]
 surface_material_override/0 = SubResource("StandardMaterial3D_038v5")
 
 [node name="InvisibleWalls" parent="." instance=ExtResource("2_26vho")]
-transform = Transform3D(0.855, 0, 0, 0, 0.855, 0, 0, 0, 0.855, 0, -0.931761, 0)
+transform = Transform3D(0.64, 0, 0, 0, 0.64, 0, 0, 0, 0.64, 0, -0.931761, 0)
 
 [editable path="emerald_beach"]

--- a/Sonic Battle Prototype/Scenes/stages/holy_summit.tscn
+++ b/Sonic Battle Prototype/Scenes/stages/holy_summit.tscn
@@ -12,12 +12,12 @@ texture_filter = 2
 [node name="Holy_Summit" type="Node3D"]
 
 [node name="holy_summit" parent="." instance=ExtResource("1_8u2r0")]
-transform = Transform3D(0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0)
+transform = Transform3D(0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, -0.242938, 0, -0.283362)
 
 [node name="holy_summit" parent="holy_summit" index="0"]
 surface_material_override/0 = SubResource("StandardMaterial3D_85cqm")
 
 [node name="InvisibleWalls" parent="." instance=ExtResource("2_kbfp6")]
-transform = Transform3D(0.635, 0, 0, 0, 0.635, 0, 0, 0, 0.635, 0, -0.578437, 0)
+transform = Transform3D(0.635, 0, 0, 0, 0.635, 0, 0, 0, 0.635, -0.242938, -0.578437, -0.283362)
 
 [editable path="holy_summit"]

--- a/Sonic Battle Prototype/Scenes/stages/library.tscn
+++ b/Sonic Battle Prototype/Scenes/stages/library.tscn
@@ -12,12 +12,12 @@ texture_filter = 2
 [node name="Library" type="Node3D"]
 
 [node name="library" parent="." instance=ExtResource("1_y5ugd")]
-transform = Transform3D(0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0)
+transform = Transform3D(0.19, 0, 0, 0, 0.2, 0, 0, 0, 0.19, 0, 0, 0)
 
 [node name="library" parent="library" index="0"]
 surface_material_override/0 = SubResource("StandardMaterial3D_1pmel")
 
 [node name="InvisibleWalls" parent="." instance=ExtResource("2_45erm")]
-transform = Transform3D(0.51, 0, 0, 0, 0.51, 0, 0, 0, 0.51, 0, -0.883603, 0)
+transform = Transform3D(0.485, 0, 0, 0, 0.485, 0, 0, 0, 0.485, 0, -0.883603, 0)
 
 [editable path="library"]

--- a/Sonic Battle Prototype/Scenes/stages/metal_depot.tscn
+++ b/Sonic Battle Prototype/Scenes/stages/metal_depot.tscn
@@ -12,12 +12,12 @@ texture_filter = 2
 [node name="Metal_Depot" type="Node3D"]
 
 [node name="metal_depot" parent="." instance=ExtResource("1_ot6s5")]
-transform = Transform3D(0.2, 0, 0, 0, 0.2, 0, 0, 0, 0.2, 0, 0, 0)
+transform = Transform3D(0.15, 0, 0, 0, 0.2, 0, 0, 0, 0.15, 0.84088, 0, 0)
 
 [node name="metal_depot" parent="metal_depot" index="0"]
 surface_material_override/0 = SubResource("StandardMaterial3D_osdox")
 
 [node name="InvisibleWalls" parent="." instance=ExtResource("2_bbgni")]
-transform = Transform3D(1.365, 0, 0, 0, 1, 0, 0, 0, 0.335, 0, -0.986975, 0)
+transform = Transform3D(1.025, 0, 0, 0, 0.751, 0, 0, 0, 0.252, 0.84088, -0.986975, 0)
 
 [editable path="metal_depot"]

--- a/Sonic Battle Prototype/Scenes/stages/sand_ocean.tscn
+++ b/Sonic Battle Prototype/Scenes/stages/sand_ocean.tscn
@@ -25,6 +25,7 @@ size = Vector2(100, 100)
 transform = Transform3D(-1.09278e-08, 0, -0.25, 0, 0.25, 0, 0.25, 0, -1.09278e-08, 0, 0, 0)
 
 [node name="NavigationRegion3D" type="NavigationRegion3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2.67363, 0)
 navigation_mesh = SubResource("NavigationMesh_qh6ae")
 
 [node name="SandOcean" parent="NavigationRegion3D" instance=ExtResource("1_xmp68")]
@@ -185,7 +186,7 @@ volume_db = -15.0
 autoplay = true
 
 [node name="Rings" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -30.6798, 0, 1.34105e-06)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -30.6798, -2.67363, 1.34105e-06)
 
 [node name="Ring" parent="Rings" instance=ExtResource("6_1o2yc")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 12.0317, 3.44294, 21.5001)
@@ -431,7 +432,7 @@ transform = Transform3D(3, 0, 0, 0, 3, 0, 0, 0, 3, 0, 0.321873, 0)
 transform = Transform3D(0.176777, 0, 0.176777, 0, 0.25, 0, -0.176777, 0, 0.176777, 0, 0.125, 0)
 
 [node name="Hazards" type="Node3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -30.6798, 0, 1.34105e-06)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -30.6798, -2.67363, 1.34105e-06)
 
 [node name="Spikes" parent="Hazards" instance=ExtResource("8_0dxp5")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -33.6444, 2.4445, 26.4889)
@@ -452,7 +453,7 @@ transform = Transform3D(10, 0, 0, 0, 10, 0, 0, 0, 10, 0, 0.0891699, 0)
 transform = Transform3D(0.25, 0, 0, 0, 0.25, 0, 0, 0, 0.25, 0, 0, 0)
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, -30.9263, 0, 1.35183e-06)
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, -30.9263, -2.67363, 1.35183e-06)
 material_override = ExtResource("10_j7yvq")
 mesh = SubResource("QuadMesh_vkwvm")
 

--- a/Sonic Battle Prototype/Scripts/CPUcontroller.gd
+++ b/Sonic Battle Prototype/Scripts/CPUcontroller.gd
@@ -53,40 +53,40 @@ func _physics_process(delta):
 	# if this node has a parent
 	if cpu_character:
 		update_life_ui()
+		select_target()
 		
-		# delay as difficulty level
-		if delay <= 0:
-			select_target()
-			
-			# if there is a target and a player target
-			if target:
-				if target.is_in_group("Player"):
-					# if player have more life
-					if is_instance_valid(target) and \
-					(target.life_total + life_offset) > cpu_character.life_total:
-						# go with defensive behaviour
-						aggressive_behaviour()
-						#cautious_behaviour()
-					
-					# else if bot have more life
-					elif is_instance_valid(target) and \
-					(cpu_character.life_total + life_offset) > target.life_total:
-						# go with aggressive behaviour
-						aggressive_behaviour()
-						#cautious_behaviour()
-					
-					# else the bot and player have less than the life_offset between their life totals
-					else:
-						# go with tactics
-						aggressive_behaviour()
-						#cautious_behaviour()
-				else:
-					# go towards rings
-					aggressive_behaviour()
-		else:
-			reset_properties()
+		if delay > 0:
 			# count down the delay
 			delay -= delta
+		
+		# if there is a target and a player target
+		if target:
+			if target.is_in_group("Player"):
+				# if player have more life
+				if is_instance_valid(target) and \
+				(target.life_total + life_offset) > cpu_character.life_total:
+					# go with defensive behaviour
+					aggressive_behaviour()
+					#cautious_behaviour()
+				
+				# else if bot have more life
+				elif is_instance_valid(target) and \
+				(cpu_character.life_total + life_offset) > target.life_total:
+					# go with aggressive behaviour
+					aggressive_behaviour()
+					#cautious_behaviour()
+				
+				# else the bot and player have less than the life_offset between their life totals
+				else:
+					# go with tactics
+					aggressive_behaviour()
+					#cautious_behaviour()
+			else:
+				# go towards rings
+				aggressive_behaviour()
+		else:
+			# no targets
+			reset_properties()
 			
 	else:
 		# set the cpu_character as the bot that have this controller

--- a/Sonic Battle Prototype/Scripts/Enemy_bot.gd
+++ b/Sonic Battle Prototype/Scripts/Enemy_bot.gd
@@ -736,24 +736,6 @@ func _on_hitbox_body_entered(body):
 		Audio.play(Audio.hit, self)
 		# If the current attack is Sonic's "pow" move, the hitbox pays attention to immunities.
 		if !pow_move || body.immunity != "pow":
-			'''
-			# reduce damage the bot causes if it's not on hard mode
-			if GlobalVariables.current_difficulty == GlobalVariables.difficulty_levels[2]:
-				var new_magnitude
-				# if it's on normal mode
-				if GlobalVariables.current_difficulty == GlobalVariables.difficulty_levels[1]:
-					new_magnitude = launch_power.length() / 2
-					launch_power = launch_power.normalized() * new_magnitude
-					# verbose to avoid warnings
-					damage_caused = int(float(damage_caused) / 2)
-				else:
-				# if it's on easy mode
-					new_magnitude = launch_power.length() / 3
-					launch_power = launch_power.normalized() * new_magnitude
-					# verbose to avoid warnings
-					damage_caused = int(float(damage_caused) / 3)
-			'''
-			
 			body.get_hurt.rpc_id(body.get_multiplayer_authority(), launch_power, self, damage_caused)
 
 
@@ -781,10 +763,10 @@ func defeated():
 # function, which is why you don't see it here.
 @rpc("any_peer","reliable","call_local")
 func get_hurt(launch_speed, owner_of_the_attack, damage_taken = 1):
-	if $sonicrigged2/AnimationPlayer.current_animation != "KO" || $sonicrigged2/AnimationPlayer.current_animation != "SPIKED":
+	if $sonicrigged2/AnimationPlayer.current_animation != "KO" and $sonicrigged2/AnimationPlayer.current_animation != "SPIKED":
 		# store the last player who damaged this character
 		last_aggressor = owner_of_the_attack
-			
+		
 		var sparks = Instantiables.SPARKS.instantiate()
 		sparks.position = position + Vector3(0, 0.1, 0)
 		get_parent().add_child(sparks)
@@ -799,7 +781,7 @@ func get_hurt(launch_speed, owner_of_the_attack, damage_taken = 1):
 				Audio.play(Audio.ring_spread, self)
 			else:
 				scatter_rings()
-			
+		
 		life_total -= damage_taken
 		
 		# A bunch of states reset to make sure getting hurt cancels them out.

--- a/Sonic Battle Prototype/Scripts/Enemy_bot.gd
+++ b/Sonic Battle Prototype/Scripts/Enemy_bot.gd
@@ -280,6 +280,8 @@ func _physics_process(delta):
 	if position.y < -5.0:
 		#cause damage
 		life_total -= 10
+		if life_total < 0:
+			life_total = 0
 		#reposition or respawn
 		if life_total <= 0:
 			defeated()
@@ -783,7 +785,8 @@ func get_hurt(launch_speed, owner_of_the_attack, damage_taken = 1):
 				scatter_rings()
 		
 		life_total -= damage_taken
-		
+		if life_total < 0:
+			life_total = 0
 		# A bunch of states reset to make sure getting hurt cancels them out.
 		hurt = true
 		falling = false

--- a/Sonic Battle Prototype/Scripts/PauseScript.gd
+++ b/Sonic Battle Prototype/Scripts/PauseScript.gd
@@ -7,31 +7,44 @@ extends Control
 
 
 func _process(_delta):
+	# don't show the restart button on online play
+	# because anyone could restart everyone else's match
 	if GlobalVariables.play_online:
 		restart_button.hide()
 	else:
 		restart_button.show()
-		
+	
+	# if the game is not paused, hide pause menu
+	if get_tree().is_paused() == false:
+		hide()
+	# if the pause menu is visible pause the game
+	if is_visible_in_tree():
+		get_tree().paused = true
+	
 	# allow to pause on a stage or hub while the game has not being won yet
 	if GlobalVariables.game_ended == false and GlobalVariables.current_character != null and (GlobalVariables.current_area != null or GlobalVariables.current_hub != null or GlobalVariables.current_stage != null):
 		# pause / resume the game when pressing "pause" button
-		if Input.is_action_just_pressed("pause"):
+		# prevent it when options menu is visible
+		if Input.is_action_just_pressed("pause") and GlobalVariables.main_menu.options_menu.is_visible_in_tree() == false:
 			toggle_pause()
 		
 		if get_tree().is_paused():
 			# show the mouse the confine it within the screen while paused
-			pause_menu.show()
+			#pause_menu.show()
+			#show()
 			Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)
 		else:
 			# hide the mouse and hold it in place while not paused
-			pause_menu.hide()
+			#pause_menu.hide()
+			hide()
 			Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 	else:
 		# game ended, score screen appeared
 		get_tree().paused = GlobalVariables.game_ended
 		# else it's on main menu
 		
-		pause_menu.hide()
+		#pause_menu.hide()
+		hide()
 		Input.set_mouse_mode(Input.MOUSE_MODE_CONFINED)
 
 
@@ -47,6 +60,7 @@ func toggle_pause():
 
 
 func restart():
+	# prevent anyone from restarting everyone else's match
 	if GlobalVariables.play_online == false:
 		get_tree().paused = false
 		

--- a/Sonic Battle Prototype/Scripts/Resources/GlobalVariables.gd
+++ b/Sonic Battle Prototype/Scripts/Resources/GlobalVariables.gd
@@ -74,7 +74,7 @@ var extra_lives: int = 2
 
 # set difficulty level
 # 					 [easy, normal, hard] respectively
-var difficulty_levels = [0.5, 0.3, 0.0]
+var difficulty_levels = [0.2, 0.1, 0.0]
 var current_difficulty = difficulty_levels[2] #difficulty.hard
 
 # win condition

--- a/Sonic Battle Prototype/Scripts/Resources/GlobalVariables.gd
+++ b/Sonic Battle Prototype/Scripts/Resources/GlobalVariables.gd
@@ -83,6 +83,12 @@ var points_to_win: int = 2
 var game_ended: bool = false
 
 
+func reset_win_conditions():
+	game_ended = false
+	character_points = 0
+	bot_points = 0
+
+
 ## the character that triggers this method is the winner of the battle
 func win(winner):
 	game_ended = true

--- a/Sonic Battle Prototype/Scripts/Resources/Instantiables.gd
+++ b/Sonic Battle Prototype/Scripts/Resources/Instantiables.gd
@@ -181,8 +181,7 @@ func go_to_stage(new_stage: PackedScene):
 	get_tree().paused = false
 	
 	# reset win condition variables
-	GlobalVariables.game_ended = false
-	GlobalVariables.character_points = 0
+	GlobalVariables.reset_win_conditions()
 	
 	delete_places()
 	

--- a/Sonic Battle Prototype/Scripts/Score_screen.gd
+++ b/Sonic Battle Prototype/Scripts/Score_screen.gd
@@ -31,9 +31,8 @@ func _on_back_to_hub_button_pressed():
 	button_pressed = true
 	
 	# reset win conditions
-	GlobalVariables.game_ended = false
-	GlobalVariables.character_points = 0
-	GlobalVariables.bot_points = 0
+	GlobalVariables.reset_win_conditions()
+	
 	if is_instance_valid(GlobalVariables.current_character) and is_instance_valid(GlobalVariables.current_character.hud):
 		GlobalVariables.current_character.hud.update_hud(GlobalVariables.current_character.life_total, GlobalVariables.current_character.special_amount, GlobalVariables.current_character.points)
 	

--- a/Sonic Battle Prototype/Scripts/Sonic.gd
+++ b/Sonic Battle Prototype/Scripts/Sonic.gd
@@ -300,6 +300,8 @@ func _physics_process(delta):
 	if position.y < -5.0:
 		#cause damage
 		life_total -= 10
+		if life_total < 0:
+			life_total = 0
 		#reposition or respawn
 		if life_total <= 0:
 			defeated()
@@ -942,6 +944,8 @@ func get_hurt(launch_speed, owner_of_the_attack, damage_taken = 1):
 				scatter_rings()
 		
 		life_total -= damage_taken
+		if life_total < 0:
+			life_total = 0
 		hud.change_life(life_total)
 		#push_warning("life: ", life_total, ", damage_taken: ", damage_taken, ", launch: ", launch_speed )
 		

--- a/Sonic Battle Prototype/Scripts/Sonic.gd
+++ b/Sonic Battle Prototype/Scripts/Sonic.gd
@@ -924,7 +924,7 @@ func defeated(): #who_owns_last_attack = null):
 # function, which is why you don't see it here.
 @rpc("any_peer","reliable","call_local")
 func get_hurt(launch_speed, owner_of_the_attack, damage_taken = 1):
-	if $sonicrigged2/AnimationPlayer.current_animation != "KO" || $sonicrigged2/AnimationPlayer.current_animation != "SPIKED":
+	if $sonicrigged2/AnimationPlayer.current_animation != "KO" and $sonicrigged2/AnimationPlayer.current_animation != "SPIKED":
 		# store the last player who damaged this character
 		last_aggressor = owner_of_the_attack
 		


### PR DESCRIPTION
stages re-scaled

bot was getting negative life points. fixed
sonic life total was going negative. fixed

character's get_hurt method logic condition from a "or" to a "and"

changed the cpu controller to not have delay on process based on difficulties, only between attacks

pause menu and options menu was still on screen when pressing esc